### PR TITLE
batches_dropped changed to a .Sum()

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/go-toolsmith/strparse v1.0.0 h1:Vcw78DnpCAKlM20kSbAyO4mPfJn/lyYA4BJUD
 github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslWct4wyljWhSRy8=
 github.com/go-toolsmith/typep v1.0.0 h1:zKymWyA1TRYvqYrYDrfEMZULyrhcnGY3x7LDKU2XQaA=
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b h1:ekuhfTjngPhisSjOJ0QWKpPQE8/rbknHaes6WVJj5Hw=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=

--- a/processor/metrics.go
+++ b/processor/metrics.go
@@ -41,6 +41,11 @@ var (
 		"bad_batch_spans_dropped",
 		"counts the number of spans dropped due to being in bad batches",
 		stats.UnitDimensionless)
+
+	StatBatchesDroppedCount = stats.Int64(
+		"batches_dropped",
+		"counts the number of batches dropped",
+		stats.UnitDimensionless)
 )
 
 // MetricTagKeys returns the metric tag keys according to the given telemetry level.
@@ -78,11 +83,10 @@ func MetricViews(level telemetry.Level) []*view.View {
 		Aggregation: view.Count(),
 	}
 	droppedBatchesView := &view.View{
-		Name:        "batches_dropped",
-		Measure:     StatDroppedSpanCount,
+		Measure:     StatBatchesDroppedCount,
 		Description: "The number of span batches dropped.",
 		TagKeys:     tagKeys,
-		Aggregation: view.Count(),
+		Aggregation: view.Sum(),
 	}
 	droppedBadBatchesView := &view.View{
 		Name:        "bad_batches_dropped",


### PR DESCRIPTION
changing the batches from a .Count() to a .Sum()
## Why?
because conditionally emitting metrics is a bad practice, when we know the value was 0.  
When setting up monitoring, the absence of errors and the error count of 0 are differing concepts.

more practically, this lets you setup the  relevant dashboards easier without having to "force" an error to see it.

Let me know what you think, I'm not confident enough in my idea to PR it to the main repo so wanted to get some feedback before I do.

## Things left to do
- [ ] update the rest of processors, in particular the memory_limiter I think can drop spans